### PR TITLE
Fixed "new" keyword and fixed angular 1.6 url slashes

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,30 +1,32 @@
 var angular = require('angular');
 
 angular.module('proxyControlsApp', [
-    require('angular-route'),
-    require('angular-sanitize'),
-    require('angular-touch')
-  ])
-  .constant('RESOURCES', {
-    DEMO_URL: '/demo',
-    SOCKET_PATH: location.protocol + '//' + location.host + '/socketpeer/'
-  })
-  .config(function($routeProvider) {
-    $routeProvider
-      .when('/', {
-        templateUrl: 'views/home.html',
-        controller: 'HomeCtrl'
-      })
-      .when('/docs', {
-        templateUrl: 'views/docs.html',
-        controller: 'DocsCtrl'
-      })
-      .when('/connect', {
-        templateUrl: 'views/connect.html',
-        controller: 'ConnectCtrl'
-      })
-      .otherwise({redirectTo: '/'});
-  });
+	require('angular-route'),
+	require('angular-sanitize'),
+	require('angular-touch')
+])
+	.constant('RESOURCES', {
+		DEMO_URL: '/demo',
+		SOCKET_PATH: location.protocol + '//' + location.host + '/socketpeer/'
+	})
+	.config(function ($routeProvider) {
+		$routeProvider
+			.when('/', {
+				templateUrl: 'views/home.html',
+				controller: 'HomeCtrl'
+			})
+			.when('/docs', {
+				templateUrl: 'views/docs.html',
+				controller: 'DocsCtrl'
+			})
+			.when('/connect', {
+				templateUrl: 'views/connect.html',
+				controller: 'ConnectCtrl'
+			})
+			.otherwise({redirectTo: '/'});
+	}).config(['$locationProvider', function ($locationProvider) {
+		$locationProvider.hashPrefix('');
+	}]);
 
 require('./controllers');
 require('./services');

--- a/server/proxy-controls-server.js
+++ b/server/proxy-controls-server.js
@@ -21,7 +21,7 @@ var assert = require('assert'),
  */
 function ProxyControlsServer (options) {
   /** @type {Koa} Koa application, to serve client UI and AJAX endpoints. */
-  this.app = koa();
+  this.app = new koa();
 
   /** @type {http.Server} Server, to support both Koa and SocketPeerServer. */
   this.server = null;
@@ -29,7 +29,7 @@ function ProxyControlsServer (options) {
   if (options.sslPort) {
     assert(options.key, 'key required for SSL.');
     assert(options.cert, 'cert required for SSL.');
-    
+
     this.app.use(forceSSL());
     http.createServer(this.app.callback()).listen(options.port);
     this.server = https.createServer({


### PR DESCRIPTION
Fixed issue: https://github.com/donmccurdy/proxy-controls-server/issues/15 for me.